### PR TITLE
Fix agent registry docstring

### DIFF
--- a/src/agents/_agent_registry.py
+++ b/src/agents/_agent_registry.py
@@ -8,7 +8,7 @@ class AgentRegistry:
 
     @classmethod
     def register(cls, agent_name: AgentName):
-        """A decorator to automatically register agent"""
+        """A decorator to automatically register an agent."""
 
         def decorator(func: Callable) -> Callable:
             cls._agents[agent_name] = func()


### PR DESCRIPTION
## Summary
- tweak `register` docstring to read "A decorator to automatically register an agent."

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845471483d483278108c147f0b881d1