### PR TITLE
Add missing dynamic relation extractor import

### DIFF
--- a/src/nodes/section_distiller.py
+++ b/src/nodes/section_distiller.py
@@ -2,8 +2,9 @@ from dataclasses import dataclass
 
 from pydantic_graph import BaseNode, GraphRunContext, End
 
-from models import MyUsage, AgentName, Section, SectionContent, Mention, build_dynamic_relation_model
+from models import MyUsage, AgentName, Section, SectionContent, build_dynamic_relation_model
 from agents._agent_registry import AgentRegistry
+from agents.dynamic_relation_extractor_agent import create_dynamic_relation_extractor_agent
 from _utils import update_usage
 
 from typing import Any


### PR DESCRIPTION
## Summary
- add `create_dynamic_relation_extractor_agent` import for SectionDistiller

## Testing
- `pyflakes src/nodes/section_distiller.py`
- `pyflakes src | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684547114f988327864979c817c5906e