### PR TITLE
Fix missing AgentName import

### DIFF
--- a/src/agents/doc_parser_agent.py
+++ b/src/agents/doc_parser_agent.py
@@ -1,6 +1,6 @@
 from agents._base import ollama_model
 from pydantic_ai.agent import Agent
-from pydantic_ai.schema import AgentName
+from models import AgentName
 
 def create_doc_parser_agent(model_name="llama3") -> Agent:
     return Agent(

--- a/src/agents/dynamic_relation_extractor_agent.py
+++ b/src/agents/dynamic_relation_extractor_agent.py
@@ -12,7 +12,7 @@ def create_dynamic_relation_extractor_agent(
 )->Agent:
     relation_extractor_agent = Agent(
             name="relation_extractor_agent",
-            model=ollama_model,
+            model=ollama_model(),
             retries=5,
             output_type=List[relation_model],
             system_prompt=DYNAMIC_RELATION_EXTRACTOR_PROMPT.format(mentions=mention_strings)

--- a/src/agents/section_distiller_agent.py
+++ b/src/agents/section_distiller_agent.py
@@ -9,7 +9,7 @@ from ._base import ollama_model
 def create_section_distiller_agent() -> Agent:
     agent = Agent(
         name=AgentName.section_distiller_agent.value,
-        model=ollama_model,
+        model=ollama_model(),
         system_prompt=SECTION_DISTILLER_AGENT,
         result_type=Section,
         retries=3

--- a/src/agents/single_distiller_agent.py
+++ b/src/agents/single_distiller_agent.py
@@ -9,7 +9,7 @@ from ._base import ollama_model
 def create_single_distiller_agent() -> Agent:
     agent = Agent(
         name=AgentName.single_distiller_agent.value,
-        model=ollama_model,
+        model=ollama_model(),
         system_prompt=SINGLE_DISTILLER_AGENT,
         result_type=DistilledUnit,
         retries=5

--- a/src/distill.py
+++ b/src/distill.py
@@ -4,7 +4,7 @@ import time
 from pydantic_graph import Graph
 from agents._agent_registry import AgentRegistry
 from agents.doc_parser_agent import create_doc_parser_agent
-from models import MyUsage
+from models import MyUsage, AgentName
 from nodes import SectionDistillerNode, DocParserNode
 
 parser = argparse.ArgumentParser()
@@ -12,7 +12,7 @@ parser.add_argument("--model", type=str, default="llama3", help="Ollama model to
 args = parser.parse_args()
 
 AgentRegistry._agents.clear()  # Optional: Reset any previously registered agents
-AgentRegistry._agents["doc_parser_agent"] = create_doc_parser_agent(model_name=args.model)
+AgentRegistry._agents[AgentName.doc_parser_agent] = create_doc_parser_agent(model_name=args.model)
 
 sample = r"C:\Users\talha\myprojects\graph-builder-agent\src\data\docs.pdf"
 graph = Graph(nodes=[DocParserNode, SectionDistillerNode])


### PR DESCRIPTION
## Summary
- implement local Ollama model using `FunctionModel`
- instantiate Ollama model for all agents
- register DocParser agent using enum key

## Testing
- `pytest -q`
- `python src/distill.py --model llama3` *(fails: All connection attempts failed)*

------
https://chatgpt.com/codex/tasks/task_e_6845c63ff6d883278c8bd9be7adb36cc